### PR TITLE
chore: switch to npm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
-# This action will publish the package to npm and create a GitHub release.
 name: Release
 
 on:
@@ -10,8 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+  id-token: write # Required for OIDC
 
 jobs:
   publish:
@@ -26,24 +25,13 @@ jobs:
         with:
           node-version: 24.15.0
 
-      # Update npm to the latest version to enable OIDC
-      # Use corepack to install pnpm
-      - name: Setup Package Managers
+      - name: Setup Pnpm
         run: |
-          npm install -g npm@latest
-          npm --version
           npm install -g corepack@latest --force
           corepack enable
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm i
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f # v4
-        with:
-          token: empty
-
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
-        with:
-          generateReleaseNotes: 'true'
+        run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@11.2.2",
+  "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }


### PR DESCRIPTION
This PR switches the release workflow to npm staged publishing with `pnpm stage publish` and aligns the repository package manager metadata on `pnpm@11.3.0`.

Related Links:
- https://docs.npmjs.com/staged-publishing/